### PR TITLE
Added rigorous session staleness checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
     
 setup(
     name="temmies",
-    version="1.2.124",
+    version="1.2.125",
     packages=find_packages(),
     description="A wrapper for the Themis website",
     long_description=l_description,

--- a/temmies/exceptions/__init__.py
+++ b/temmies/exceptions/__init__.py
@@ -1,0 +1,11 @@
+"""temmies exception types."""
+
+from .course_unavailable import CourseUnavailable
+from .illegal_action import IllegalAction
+from .session_expired import SessionExpired
+
+__all__ = [
+	"CourseUnavailable",
+	"IllegalAction",
+	"SessionExpired",
+]

--- a/temmies/exceptions/__init__.py
+++ b/temmies/exceptions/__init__.py
@@ -2,10 +2,11 @@
 
 from .course_unavailable import CourseUnavailable
 from .illegal_action import IllegalAction
-from .session_expired import SessionExpired
+from .session_expired import SessionExpired, SessionRefreshed
 
 __all__ = [
 	"CourseUnavailable",
 	"IllegalAction",
 	"SessionExpired",
+	"SessionRefreshed",
 ]

--- a/temmies/exceptions/session_expired.py
+++ b/temmies/exceptions/session_expired.py
@@ -1,0 +1,9 @@
+"""Exceptions related to authentication/session state."""
+
+
+class SessionExpired(Exception):
+    """Raised when the current Themis session is no longer authenticated.
+
+    This typically happens when cookies expire or the server redirects to the
+    login flow.
+    """

--- a/temmies/exceptions/session_expired.py
+++ b/temmies/exceptions/session_expired.py
@@ -7,3 +7,9 @@ class SessionExpired(Exception):
     This typically happens when cookies expire or the server redirects to the
     login flow.
     """
+
+class SessionRefreshed(Exception):
+    """Raised when the session cookies have been refreshed.
+
+    This is mainly used internally to signal that the session should be retried.
+    """

--- a/temmies/themis.py
+++ b/temmies/themis.py
@@ -1,6 +1,6 @@
-"""
-Main class for the Themis API using the new JSON endpoints.
-"""
+"""Main class for the Themis API using the new JSON endpoints."""
+# pyright: basic
+from __future__ import annotations
 
 from requests import Session
 from selenium import webdriver
@@ -14,6 +14,8 @@ from json import dumps
 from .year import Year
 import getpass
 import keyring
+
+from .exceptions import SessionExpired
 
 class Themis:
     """
@@ -37,6 +39,7 @@ class Themis:
             session (requests.Session): Authenticated session.
         """
         self.base_url = "https://themis.housing.rug.nl"
+        self._relogin_attempted = False
         self.session = self._setup_agent()
         
         self.user, self.password = None, None
@@ -52,7 +55,13 @@ class Themis:
         else:
             self.session.cookies.update(cookies)
             if not self.check_session():
-                self.session = self.login(self.session)
+                # Attempt to refresh stale cookies
+                try:
+                    self.refresh_cookies()
+                except SessionExpired:
+                    raise SessionExpired(
+                        "Provided cookies are stale or malformed and re-authentication failed. Please create a new Themis() instance without cookies."
+                    )
     
     def _get_password(self) -> str:
         """
@@ -79,17 +88,85 @@ class Themis:
 
         session.headers.update({"User-Agent": user_agent})
 
+        def _raise_if_session_expired(response, *args, **kwargs):  # noqa: ANN001
+            request_url = getattr(getattr(response, "request", None), "url", "") or ""
+            final_url = getattr(response, "url", "") or ""
+
+            should_reauth = False
+            
+            if "/login" in final_url and ("/login" not in request_url):
+                should_reauth = True
+            elif getattr(response, "status_code", None) in (401, 403):
+                should_reauth = True
+            else:
+                content_type = (response.headers.get("Content-Type") or "").lower()
+                if "text/html" in content_type and ("/login" not in request_url):
+                    body = response.text or ""
+                    if "signon.rug.nl" in body:
+                        should_reauth = True
+            
+            if should_reauth:
+                if self._relogin_attempted:
+                    raise SessionExpired(
+                        "Session expired and automatic re-login already attempted. Please create a new Themis() instance."
+                    )
+                
+                self._relogin_attempted = True
+                
+                self.refresh_cookies()
+                
+                raise SessionExpired(
+                    "Session expired. Cookies have been refreshed. Please retry your request."
+                )
+
+            return response
+
+        # clean hook solution
+        hooks = session.hooks.get("response", [])
+        if _raise_if_session_expired not in hooks:
+            hooks.append(_raise_if_session_expired)
+            session.hooks["response"] = hooks
+
         return session
 
     def check_session(self) -> bool:
         """
         Check if the session is still valid.
         """
+
+        # fuck you matt
+        navigation_url = f"{self.base_url}/api/navigation/"
         
-        # look at the /login and find a pre tag
-        login_url = f"{self.base_url}/login"
-        response = self.session.get(login_url)
-        return "pre" in response.text
+        original_hooks = self.session.hooks.get("response", [])
+        self.session.hooks["response"] = []
+        
+        try:
+            response = self.session.get(navigation_url)
+            
+            if response.status_code != 200:
+                return False
+
+            try:
+                response.json()
+            except ValueError:
+                return False
+
+            return True
+        finally:
+            self.session.hooks["response"] = original_hooks
+    
+    def refresh_cookies(self) -> None:
+        """
+        Refresh/replace session cookies by re-authenticating.
+        Raises SessionExpired if re-authentication fails.
+        """
+        self.session.cookies.clear()
+        self._relogin_attempted = False
+        self.session = self.login(self.session)
+        if not self.check_session():
+            raise SessionExpired(
+                "Failed to refresh session cookies. Re-authentication was attempted but the session is still invalid."
+            )
     
         
     def login(self, session: Session) -> Session:

--- a/temmies/themis.py
+++ b/temmies/themis.py
@@ -15,7 +15,7 @@ from .year import Year
 import getpass
 import keyring
 
-from .exceptions import SessionExpired
+from .exceptions import SessionExpired, SessionRefreshed
 
 class Themis:
     """
@@ -107,7 +107,7 @@ class Themis:
             
             if should_reauth:
                 if self._relogin_attempted:
-                    raise SessionExpired(
+                    raise SessionRefreshed(
                         "Session expired and automatic re-login already attempted. Please create a new Themis() instance."
                     )
                 
@@ -115,7 +115,7 @@ class Themis:
                 
                 self.refresh_cookies()
                 
-                raise SessionExpired(
+                raise SessionRefreshed(
                     "Session expired. Cookies have been refreshed. Please retry your request."
                 )
 


### PR DESCRIPTION
Fix for #22.

In conventional use (i.e. keeping one `Themis` instance alive), the library will now throw a `SessionRefreshed` after attempting to refresh cookies.

In usage in which a new `Themis` instance is created provided with stale/malformed cookies (such as [temmies-cli](https://github.com/Code-For-Groningen/temmies), temmies will prompt the user for re-authentication and continue without throwing.

New exception: `SessionExpired` when re-authentication is unsuccessful.